### PR TITLE
Save MangoPay Card ID

### DIFF
--- a/mangopay/models.py
+++ b/mangopay/models.py
@@ -384,12 +384,8 @@ class MangoPayCardRegistration(models.Model):
             "cardRegistrationURL": card_registration.CardRegistrationURL}
         return preregistration_data
 
-    def request_card(self, card_registration_data):
-        client = get_mangopay_api_client()
-        card_registration = client.cardRegistrations.Get(self.mangopay_id)
-        card_registration.RegistrationData = card_registration_data
-        card_registration = client.cardRegistrations.Update(card_registration)
-        self.mangopay_card.mangopay_id = card_registration.CardId
+    def save_mangopay_card_id(self, mangopay_card_id):
+        self.mangopay_card.mangopay_id = mangopay_card_id
         self.mangopay_card.save()
 
     def save(self, *args, **kwargs):

--- a/mangopay/tests/card_registration.py
+++ b/mangopay/tests/card_registration.py
@@ -32,15 +32,11 @@ class MangoPayCardRegistrationTests(TestCase):
         self.assertIsNotNone(preregistration_data["accessKey"])
         self.assertIsNotNone(preregistration_data["cardRegistrationURL"])
 
-    @patch("mangopay.models.get_mangopay_api_client")
-    def test_request_card(self, mock_client):
+    def test_save_mangopay_card_id(self):
         card_id = 42
         card_registration_id = 32
-        mock_client.return_value = MockMangoPayApi(
-            card_registration_id=card_registration_id,
-            card_id=card_id)
         self.card_registration.mangopay_id = card_registration_id
         self.assertIsNone(self.card_registration.mangopay_card.mangopay_id)
-        self.card_registration.request_card("CardRegistrationData")
+        self.card_registration.save_mangopay_card_id(card_id)
         self.assertEqual(self.card_registration.mangopay_card.mangopay_id,
                          card_id)


### PR DESCRIPTION
We don't need the request card method as this will be done in the front-end, replacing it with save_mangopay_card_id
