### PR TITLE
Create seperate page model

### DIFF
--- a/mangopay/tasks.py
+++ b/mangopay/tasks.py
@@ -25,12 +25,13 @@ def create_mangopay_bank_account(id):
 
 
 @task
-def create_mangopay_document_and_page_and_ask_for_validation(id):
+def create_mangopay_document_and_pages_and_ask_for_validation(id):
     document = MangoPayDocument.objects.get(
         id=id, mangopay_id__isnull=True, file__isnull=False,
         type__isnull=False)
     document.create()
-    document.create_page()
+    for page in document.mangopay_pages.all():
+        page.create()
     document.ask_for_validation()
     eta = next_weekday()
     update_document_status.apply_async((), {"id": id}, eta=eta)

--- a/mangopay/tests/__init__.py
+++ b/mangopay/tests/__init__.py
@@ -10,3 +10,4 @@ from wallet import MangoPayWalletTests
 from payout import MangoPayPayOutTests
 from payin import MangoPayPayInTests
 from refund import MangoPayRefundTests
+from page import MangoPayPageTests

--- a/mangopay/tests/document.py
+++ b/mangopay/tests/document.py
@@ -1,5 +1,3 @@
-import os
-
 from django.test import TestCase
 
 from mock import patch
@@ -39,9 +37,3 @@ class MangoPayDocumentTests(TestCase):
         self.document.ask_for_validation()
         MangoPayDocument.objects.get(id=self.document.id,
                                      status=VALIDATION_ASKED)
-
-    @patch("mangopay.models.get_mangopay_api_client")
-    def test_create_page(self, mock_client):
-        mock_client.return_value = MockMangoPayApi()
-        self.document.file = os.getcwd() + "/mangopay/tests/test.png"
-        self.document.create_page()

--- a/mangopay/tests/factories.py
+++ b/mangopay/tests/factories.py
@@ -8,7 +8,7 @@ import factory
 from ..models import (MangoPayNaturalUser, MangoPayBankAccount,
                       MangoPayLegalUser, MangoPayWallet,
                       MangoPayCardRegistration, MangoPayCard,
-                      MangoPayRefund, MangoPayPayIn,
+                      MangoPayRefund, MangoPayPayIn, MangoPayPage,
                       MangoPayPayOut, MangoPayDocument)
 from ..constants import IDENTITY_PROOF, BUSINESS
 
@@ -117,8 +117,14 @@ class MangoPayDocumentFactory(factory.DjangoModelFactory):
     mangopay_user = factory.SubFactory(MangoPayNaturalUserFactory)
     type = IDENTITY_PROOF
     status = None
-    file = None
     refused_reason_message = None
+
+
+class MangoPayPageFactory(factory.DjangoModelFactory):
+    FACTORY_FOR = MangoPayPage
+
+    document = factory.SubFactory(MangoPayDocumentFactory)
+    file = "fake_file.jpg"
 
 
 class MangoPayWalletFactory(factory.DjangoModelFactory):

--- a/mangopay/tests/page.py
+++ b/mangopay/tests/page.py
@@ -1,0 +1,20 @@
+import os
+
+from django.test import TestCase
+
+from mock import patch
+
+from .factories import MangoPayPageFactory
+from .client import MockMangoPayApi
+
+
+class MangoPayPageTests(TestCase):
+
+    def setUp(self):
+        self.page = MangoPayPageFactory()
+
+    @patch("mangopay.models.get_mangopay_api_client")
+    def test_create(self, mock_client):
+        mock_client.return_value = MockMangoPayApi()
+        self.page.file = os.getcwd() + "/mangopay/tests/test.png"
+        self.page.create()

--- a/run_tests.py
+++ b/run_tests.py
@@ -7,6 +7,7 @@ from optparse import OptionParser
 
 from django.conf import settings
 from django.core.management import call_command
+from django.core.files.storage import default_storage
 
 
 def main():
@@ -50,6 +51,7 @@ def main():
             "django.contrib.sites",
             app_name,
         ),
+        "MANGOPAY_PAGE_STORAGE": default_storage,
         "LOGGING": {
             'version': 1,
             'disable_existing_loggers': False,


### PR DESCRIPTION
- Will allow users to upload multiple pages
- Follows mangopay API structure better
- Allows for switching out of Storage (on for example s3 instead)
