### PR TITLE
Store Money On PayOut Object

### DIFF
--- a/mangopay/models.py
+++ b/mangopay/models.py
@@ -360,18 +360,13 @@ class MangoPayPayOut(models.Model):
     fees = MoneyField(default=0, default_currency="EUR", decimal_places=2,
                       max_digits=12)
 
-    def create(self, debited_funds=None, fees=None, tag=''):
+    def create(self, tag=''):
         pay_out = PayOut()
         pay_out.Tag = tag
         pay_out.AuthorId = self.mangopay_user.mangopay_id
-        if not debited_funds:
-            debited_funds = self.mangopay_wallet.balance()
-        pay_out.DebitedFunds = python_money_to_mangopay_money(debited_funds)
-        self.debited_funds = debited_funds
-        if not fees:
-            fees = PythonMoney(0, debited_funds.currency)
-        self.fees = fees
-        pay_out.Fees = python_money_to_mangopay_money(fees)
+        pay_out.DebitedFunds = python_money_to_mangopay_money(
+            self.debited_funds)
+        pay_out.Fees = python_money_to_mangopay_money(self.fees)
         pay_out.DebitedWalletId = self.mangopay_wallet.mangopay_id
         details = PayOutPaymentDetailsBankWire()
         details.BankAccountId = self.mangopay_bank_account.id

--- a/mangopay/tasks.py
+++ b/mangopay/tasks.py
@@ -63,6 +63,6 @@ def create_mangopay_wallet(id, currency, description=""):
 
 
 @task
-def create_mangopay_pay_out(id, debited_funds=None, fees=None, tag=''):
+def create_mangopay_pay_out(id, tag=''):
     payout = MangoPayPayOut.objects.get(id=id, mangopay_id__isnull=True)
-    payout.create(debited_funds, fees, tag)
+    payout.create(tag)

--- a/mangopay/tests/factories.py
+++ b/mangopay/tests/factories.py
@@ -3,6 +3,7 @@ import datetime
 from django.contrib.auth.models import User
 from django.contrib.auth.hashers import make_password
 
+from money import Money
 import factory
 
 from ..models import (MangoPayNaturalUser, MangoPayBankAccount,
@@ -143,6 +144,8 @@ class MangoPayPayOutFactory(factory.DjangoModelFactory):
     mangopay_bank_account = factory.SubFactory(MangoPayBankAccountFactory)
     execution_date = None
     status = None
+    debited_funds = Money(0, "EUR")
+    fees = Money(0, "EUR")
 
 
 class MangoPayPayInFactory(factory.DjangoModelFactory):

--- a/mangopay/tests/payout.py
+++ b/mangopay/tests/payout.py
@@ -12,7 +12,8 @@ from .client import MockMangoPayApi
 class MangoPayPayOutTests(TestCase):
 
     def setUp(self):
-        self.pay_out = MangoPayPayOutFactory()
+        self.pay_out = MangoPayPayOutFactory(debited_funds=Money(100, "SEK"),
+                                             fees=Money(10, "SEK"))
 
     @patch("mangopay.models.get_mangopay_api_client")
     def test_create_with_defaults(self, mock_client):
@@ -27,9 +28,7 @@ class MangoPayPayOutTests(TestCase):
         id = 76
         mock_client.return_value = MockMangoPayApi(pay_out_id=id)
         self.assertIsNone(self.pay_out.mangopay_id)
-        self.pay_out.create(debited_funds=Money(100, "EUR"),
-                            fees=Money(5, "EUR"),
-                            tag='sdgsd')
+        self.pay_out.create(tag='sdgsd')
         MangoPayPayOut.objects.get(id=self.pay_out.id, mangopay_id=id)
 
     @patch("mangopay.models.get_mangopay_api_client")


### PR DESCRIPTION
- This will allow us to create reports about how much money was paid out for acconting without hitting the mangopay api a billion times
