### PR TITLE
Djano-mango requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Django==1.4.8
 django-iban==0.2.6
 celery==3.0.12
 -e git+https://github.com/izquierdo/python-money.git@5c14ce00d9472ddce55bb7a799f6051509dbd092#egg=python_money
--e git+https://github.com/FundedByMe/mangopay2-python-sdk.git@secure-mode-redirect-url#egg=mangopaysdk
+mangopay2-python-sdk==1.4.1
 Sphinx==1.2.2
 django-model-utils==1.4.0
 django-storages==1.1.8


### PR DESCRIPTION
Switch to using offical mangopay-sdk for quicker releases. They released the needed fix for  PreAuthorized PayIns.

See: https://github.com/MangoPay/mangopay2-python-sdk/releases

They have made some other nices changes that I wanted to pull in. Better printing of error messages and logging control. But the haven't yet been released and their build is failing so I think we can wait a bit longer for nicer errors.

https://github.com/MangoPay/mangopay2-python-sdk/compare/v1.4.1...master
