### PR TITLE
Change the PayIn credited user to be the same as the author

### DIFF
--- a/mangopay/models.py
+++ b/mangopay/models.py
@@ -522,7 +522,7 @@ class MangoPayPayIn(models.Model):
     def create(self, secure_mode_return_url):
         pay_in = PayIn()
         pay_in.AuthorId = self.mangopay_user.mangopay_id
-        pay_in.CreditedUserId = self.mangopay_wallet.mangopay_user.mangopay_id
+        pay_in.CreditedUserId = self.mangopay_user.mangopay_id
         pay_in.CreditedWalletId = self.mangopay_wallet.mangopay_id
         pay_in.DebitedFunds = python_money_to_mangopay_money(
             self.debited_funds)


### PR DESCRIPTION
The way it works now, the owner of the money in the wallet is the wallet owner, requires the wallet owner to be KYC verified for a refund to be processed.
According to MangoPay IT Support changing the PayIn credited user to be the same as the author of the payment, will make the author of the payment the owner of the money they put into the wallet and will remove the need for the wallet owner to be KYC verified until a payout needs to be created.
