### PR TITLE
Always require ID for a business or organization

### DIFF
--- a/mangopay/models.py
+++ b/mangopay/models.py
@@ -252,7 +252,7 @@ class MangoPayLegalUser(MangoPayUser):
                 and super(MangoPayLegalUser, self).has_regular_authenication())
 
     def _required_documents_types(self):
-        types = [REGISTRATION_PROOF]
+        types = [IDENTITY_PROOF, REGISTRATION_PROOF]
         if self.type == BUSINESS:
             types.append(SHAREHOLDER_DECLARATION)
         elif self.type == ORGANIZATION:

--- a/mangopay/tests/users.py
+++ b/mangopay/tests/users.py
@@ -114,6 +114,9 @@ class RegularAuthenticationMangoPayLegalUserTests(
     def setUp(self):
         super(RegularAuthenticationMangoPayLegalUserTests, self).setUp()
         self.user = RegularAuthenticationMangoPayLegalUserFactory()
+        self.identity_proof = MangoPayDocumentFactory(
+            mangopay_user=self.user, type=IDENTITY_PROOF,
+            status=VALIDATED)
         self.registration_proof = MangoPayDocumentFactory(
             mangopay_user=self.user, type=REGISTRATION_PROOF,
             status=VALIDATED)
@@ -132,10 +135,18 @@ class RegularAuthenticationMangoPayLegalUserTests(
         self.assertEqual(
             self.user.required_documents_types_that_need_to_be_reuploaded(),
             [])
+        self.identity_proof.status = REFUSED
+        self.identity_proof.save()
         self.registration_proof.status = REFUSED
         self.registration_proof.save()
         self.shareholder_declaration.status = REFUSED
         self.shareholder_declaration.save()
+        self.assertEqual(
+            self.user.required_documents_types_that_need_to_be_reuploaded(),
+            [IDENTITY_PROOF, REGISTRATION_PROOF, SHAREHOLDER_DECLARATION])
+        MangoPayDocumentFactory(mangopay_user=self.user,
+                                type=IDENTITY_PROOF,
+                                status=VALIDATION_ASKED)
         self.assertEqual(
             self.user.required_documents_types_that_need_to_be_reuploaded(),
             [REGISTRATION_PROOF, SHAREHOLDER_DECLARATION])


### PR DESCRIPTION
This is to meet MangoPay's KYC rules for regular authentication: https://docs.mangopay.com/api-references/kyc-rules/